### PR TITLE
fix: close hint in rerender + step logic

### DIFF
--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -25,7 +25,7 @@ export function getHooks<HintParams, Presets extends string, Steps extends strin
         }, [step]);
 
         const closeHint = useCallback(() => {
-            controller.closeHintForStep(step);
+            controller.closeHintByUser(step);
         }, [step]);
 
         return {pass, ref: onRefChange, closeHint};
@@ -47,7 +47,7 @@ export function getHooks<HintParams, Presets extends string, Steps extends strin
         );
         return {
             ...popupData,
-            onClose: controller.closeHint,
+            onClose: controller.closeHintByUser,
         };
     };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ let controllerRef: Controller<object, string, string>;
 
 export function closeHint() {
     if (controllerRef !== null) {
-        controllerRef.closeHint();
+        controllerRef.closeHintByUser();
     }
 }
 

--- a/src/tests/controller.test.ts
+++ b/src/tests/controller.test.ts
@@ -1,6 +1,36 @@
 import {Controller} from '../controller';
 import {getAnchorElement, getOptions, getOptionsWithHooks} from './utils';
 
+describe('init with not full data', function () {
+    it('empty progress, reachElement -> show hint', async function () {
+        const options = getOptions();
+        // @ts-ignore
+        options.getProgressState = () => Promise.resolve({});
+
+        const controller = new Controller(options);
+        await controller.stepElementReached({
+            stepSlug: 'openBoard',
+            element: getAnchorElement(),
+        });
+
+        expect(options.showHint).toHaveBeenCalled();
+    });
+
+    it('should init with empty base state', async function () {
+        const options = getOptions();
+        // @ts-ignore
+        options.baseState = undefined;
+
+        const controller = new Controller(options);
+        await controller.stepElementReached({
+            stepSlug: 'openBoard',
+            element: getAnchorElement(),
+        });
+
+        // not throw error
+    });
+});
+
 describe('hooks', function () {
     it('reachElement -> onShowHint called', async function () {
         const options = getOptionsWithHooks();

--- a/src/tests/steps.test.ts
+++ b/src/tests/steps.test.ts
@@ -183,23 +183,6 @@ describe('pass step', function () {
         });
     });
 
-    it('finish preset -> remove from active add to finished', async function () {
-        const options = getOptions(
-            {},
-            {presetPassedSteps: {createProject: ['openBoard', 'createSprint']}},
-        );
-
-        const controller = new Controller(options);
-        await controller.passStep('createIssue');
-
-        const newBaseState = options.onSave.state.mock.calls[0][0];
-        const newProgressState = options.onSave.progress.mock.calls[0][0];
-
-        expect(newBaseState.activePresets).toEqual([]);
-        expect(newProgressState.finishedPresets).toEqual(['createProject']);
-        expect(options.onSave.progress).toHaveBeenCalledTimes(1);
-    });
-
     describe('step hooks', function () {
         it('pass step -> call onPass hook', async function () {
             const options = getOptions();
@@ -221,6 +204,20 @@ describe('find next step', function () {
 
         // @ts-ignore
         expect(Controller.findNextUnpassedStep(undefined, passedSteps)).toBe(undefined);
+    });
+
+    it('no passed steps -> first preset step', function () {
+        const preset = ['createBoard', 'openBoard', 'createIssue', 'changeIssueStatus'];
+        const passedSteps = [] as string[];
+
+        expect(Controller.findNextUnpassedStep(preset, passedSteps)).toBe('createBoard');
+    });
+
+    it('no passed steps -> first preset step11', function () {
+        const preset = ['createBoard', 'openBoard', 'createIssue', 'changeIssueStatus'];
+        const passedSteps = ['createBoard', 'createIssue', 'changeIssueStatus'];
+
+        expect(Controller.findNextUnpassedStep(preset, passedSteps)).toBe(undefined);
     });
 
     it('pass some step from preset', function () {
@@ -249,5 +246,12 @@ describe('find next step', function () {
         const passedSteps = ['createBoard', 'clickedOnBoard', 'createIssue'];
 
         expect(Controller.findNextUnpassedStep(preset, passedSteps)).toBe('changeIssueStatus');
+    });
+
+    it('all steps passed -> undefined', function () {
+        const preset = ['createBoard', 'openBoard', 'createIssue', 'changeIssueStatus'];
+        const passedSteps = ['createBoard', 'openBoard', 'createIssue', 'changeIssueStatus'];
+
+        expect(Controller.findNextUnpassedStep(preset, passedSteps)).toBe(undefined);
     });
 });


### PR DESCRIPTION
Problems fixed
- hint closes on component rerender
- preset with skipped step cannot be finished
- hint shows after preset finish